### PR TITLE
CompatHelper: bump compat for Roots to 3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Documenter = "1.14.1"
 Elliptic = "1"
 Polynomials = "4.1.1"
 QuadGK = "2.6"
-Roots = "2.1"
+Roots = "2.1, 3"
 julia = "^1.10"
 
 [extras]


### PR DESCRIPTION
CompatHelper generated this branch to allow Roots 3 while keeping existing compat. The scheduled workflow could push the branch but could not create the pull request because repository settings currently disallow GitHub Actions from creating pull requests.